### PR TITLE
[WIP] Tests

### DIFF
--- a/config/main.go
+++ b/config/main.go
@@ -111,6 +111,62 @@ func NewConfigFromFlags() (Config, error) {
 	return c, nil
 }
 
+func NewTestConfig() Config {
+	host, port, _ := splitString(defaultAddr)
+	electrsHost, electrsPort, _ := splitString(defaultElectrsAddr)
+	rpcHost, rpcPort, _ := splitString(defaultRPCAddr)
+	rpcUser, rpcPassword, _ := splitString(defaultRPCCookie)
+
+	c := &config{}
+	c.server.loggerEnabled = defaultLoggerEnabled
+	c.server.tlsEnabled = defaultTLSEnabled
+	c.server.faucetEnabled = true
+	c.server.miningEnabled = true
+	c.server.host = host
+	c.server.port = port
+	c.server.chain = defaultChain
+
+	c.electrs.host = electrsHost
+	c.electrs.port = electrsPort
+
+	c.rpcServer.host = rpcHost
+	c.rpcServer.port = rpcPort
+	c.rpcServer.user = rpcUser
+	c.rpcServer.password = rpcPassword
+
+	return c
+}
+
+func NewTestLiquidConfig() Config {
+	defaultChain := "liquid"
+	defaultRPCAddr := "localhost:18884"
+	defaultElectrsAdrr := "localhost:3022"
+
+	host, port, _ := splitString(defaultAddr)
+	electrsHost, electrsPort, _ := splitString(defaultElectrsAdrr)
+	rpcHost, rpcPort, _ := splitString(defaultRPCAddr)
+	rpcUser, rpcPassword, _ := splitString(defaultRPCCookie)
+
+	c := &config{}
+	c.server.loggerEnabled = defaultLoggerEnabled
+	c.server.tlsEnabled = defaultTLSEnabled
+	c.server.faucetEnabled = true
+	c.server.miningEnabled = true
+	c.server.host = host
+	c.server.port = port
+	c.server.chain = defaultChain
+
+	c.electrs.host = electrsHost
+	c.electrs.port = electrsPort
+
+	c.rpcServer.host = rpcHost
+	c.rpcServer.port = rpcPort
+	c.rpcServer.user = rpcUser
+	c.rpcServer.password = rpcPassword
+
+	return c
+}
+
 func (c *config) IsTLSEnabled() bool {
 	return c.server.tlsEnabled
 }

--- a/router/faucet_handler_test.go
+++ b/router/faucet_handler_test.go
@@ -1,0 +1,95 @@
+package router
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const (
+	address       = "mpSGWQvbAiRt2UNLST1CdWUufoPVsVwLyK"
+	liquidAddress = "CTEsqL1x9ooWWG9HBaHUpvS2DGJJ4haYdkTQPKj9U8CCdwT5vcudhbYUT8oQwwoS11aYtdznobfgT8rj"
+
+	badAddress       = "mN9Zw9TwwKoYXrBzVFuioXab3xeu4WWr1wk"
+	badLiquidAddress = "CTEqd9wVbwWwNnXuDbN9q6NMWCpHX6FeqaYgBsafvpQhQV2v5aHWGkYrns43ogncYcjksru2cLVa7MJv"
+)
+
+// For bitcoin, this implicitly tests also the broadcast endpoint since
+// for this chain the faucet gets a signed transaction from the faucet
+// and broadcasts it via the cited endpoint
+func TestFaucetHandler(t *testing.T) {
+	rr := makeFaucetRequest(false, address)
+	resp := rr.Body.String()
+	status := rr.Code
+	expectedStatus := http.StatusOK
+
+	if status != expectedStatus {
+		t.Fatal(resp)
+	}
+
+	t.Log("tx hash:", resp)
+}
+
+func TestFaucetHandlerShouldFail(t *testing.T) {
+	rr := makeFaucetRequest(false, badAddress)
+	resp := strings.TrimSpace(rr.Body.String())
+	status := rr.Code
+	expectedStatus := http.StatusInternalServerError
+	expectedResp := fmt.Sprintf("Method createrawtransaction failed with error: Invalid Bitcoin address: %s", badAddress)
+
+	if status != expectedStatus {
+		t.Fatalf("Expected status: %d, got: %d\n check out the response: %s", expectedStatus, status, resp)
+	}
+
+	if resp != expectedResp {
+		t.Fatalf("Expected response: %s, got: %s", expectedResp, resp)
+	}
+}
+
+func TestLiquidFaucetHandler(t *testing.T) {
+	rr := makeFaucetRequest(true, liquidAddress)
+	resp := rr.Body.String()
+	status := rr.Code
+	expectedStatus := http.StatusOK
+
+	if status != expectedStatus {
+		t.Fatal(resp)
+	}
+
+	t.Log("tx hash:", resp)
+}
+
+func TestLiquidFaucetHandlerShouldFail(t *testing.T) {
+	rr := makeFaucetRequest(true, badLiquidAddress)
+	resp := strings.TrimSpace(rr.Body.String())
+	status := rr.Code
+	expectedStatus := http.StatusInternalServerError
+	expectedResp := "Method sendtoaddress failed with error: Invalid Bitcoin address"
+
+	if status != expectedStatus {
+		t.Fatalf("Expected status: %d, got: %d\n check out the response: %s", expectedStatus, status, resp)
+	}
+
+	if resp != expectedResp {
+		t.Fatalf("Expected response: %s, got: %s", expectedResp, resp)
+	}
+}
+
+func makeFaucetRequest(isLiquid bool, addr string) *httptest.ResponseRecorder {
+	router := newTestingRouter(isLiquid)
+
+	payloadBuffer := &bytes.Buffer{}
+	json.NewEncoder(payloadBuffer).Encode(map[string]string{"address": addr})
+
+	req, _ := http.NewRequest("POST", "/faucet", payloadBuffer)
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(router.HandleFaucetRequest)
+
+	handler.ServeHTTP(rr, req)
+
+	return rr
+}

--- a/router/main_test.go
+++ b/router/main_test.go
@@ -1,0 +1,51 @@
+package router
+
+import (
+	"testing"
+
+	cfg "github.com/vulpemventures/nigiri-chopsticks/config"
+)
+
+func TestNewRouter(t *testing.T) {
+	router := newTestingRouter(false)
+	if router == nil {
+		t.Fatal("Failed to create router")
+	}
+	if router.RPCClient == nil {
+		t.Fatal("Failed to create router's RPC client")
+	}
+	if router.Faucet == nil {
+		t.Fatal("Failed to create router's faucet")
+	}
+	if router.Config.Chain() != "bitcoin" {
+		t.Fatal("Router is not configured for bitcoin chain")
+	}
+}
+
+func TestNewLiquidRouter(t *testing.T) {
+	router := newTestingRouter(true)
+	if router == nil {
+		t.Fatal("Failed to create router")
+	}
+	if router.RPCClient == nil {
+		t.Fatal("Failed to create router's RPC client")
+	}
+	if router.Faucet == nil {
+		t.Fatal("Failed to create router's faucet")
+	}
+	if router.Config == nil {
+		t.Fatal("Failed to create router's configuration")
+	}
+	if router.Config.Chain() != "liquid" {
+		t.Fatal("Router is not configured for liquid sidechain")
+	}
+}
+
+func newTestingRouter(isLiquid bool) *Router {
+	config := cfg.NewTestConfig()
+	if isLiquid {
+		config = cfg.NewTestLiquidConfig()
+	}
+
+	return NewRouter(config)
+}


### PR DESCRIPTION
Running tests requires having a nigiri started in regtest network with liquid.

For the bitcoin chain, testing the faucet endpoint also means testing the broadcast one, while for the liquid I would love to use a `btcutil`-like package to create, sign and blind transactions instead of calling the liquid-cli's methods of the underlying node.