### PR TITLE
Add CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: go
+
+go:
+  - 1.13.x
+
+env:
+  - GO111MODULE=on
+
+services:
+  - docker
+
+before_install:
+  - curl https://travis.nigiri.network | bash
+  - docker-compose up -d;
+
+install:
+  - bash scripts/install
+
+script:
+  - bash scripts/test ci;
+  - bash scripts/build linux amd64;
+
+after_script:
+  - docker-compose down

--- a/config/main.go
+++ b/config/main.go
@@ -154,6 +154,11 @@ func splitString(addr string) (string, string, bool) {
 
 func NewTestConfig() Config {
 	c := &config{}
+	rpcPort := "18433"
+	if os.Getenv("CI") == "true" {
+		rpcPort = "18443"
+	}
+
 	c.server.tlsEnabled = false
 	c.server.loggerEnabled = false
 	c.server.faucetEnabled = true
@@ -162,11 +167,11 @@ func NewTestConfig() Config {
 	c.server.port = "7000"
 	c.server.chain = "bitcoin"
 
-	c.electrs.host = os.Getenv("ADDR")
+	c.electrs.host = "localhost"
 	c.electrs.port = "3002"
 
-	c.rpcServer.host = os.Getenv("ADDR")
-	c.rpcServer.port = "18433"
+	c.rpcServer.host = "localhost"
+	c.rpcServer.port = rpcPort
 	c.rpcServer.user = "admin1"
 	c.rpcServer.password = "123"
 
@@ -175,6 +180,11 @@ func NewTestConfig() Config {
 
 func NewLiquidTestConfig() Config {
 	c := &config{}
+	rpcPort := "7041"
+	if os.Getenv("CI") == "true" {
+		rpcPort = "18884"
+	}
+
 	c.server.tlsEnabled = false
 	c.server.loggerEnabled = false
 	c.server.faucetEnabled = true
@@ -183,11 +193,11 @@ func NewLiquidTestConfig() Config {
 	c.server.port = "7001"
 	c.server.chain = "liquid"
 
-	c.electrs.host = os.Getenv("ADDR")
+	c.electrs.host = "localhost"
 	c.electrs.port = "3012"
 
-	c.rpcServer.host = os.Getenv("ADDR")
-	c.rpcServer.port = "7041"
+	c.rpcServer.host = "localhost"
+	c.rpcServer.port = rpcPort
 	c.rpcServer.user = "admin1"
 	c.rpcServer.password = "123"
 

--- a/scripts/test
+++ b/scripts/test
@@ -3,7 +3,8 @@
 set -e
 
 case $1 in
-  local) addr="localhost";;
+  local) ci="false";;
+  ci) ci="true";;
   *) echo "Invalid option. Aborting."; exit 1;;
 esac
 
@@ -11,6 +12,6 @@ PARENT_PATH=$(dirname $(cd $(dirname $0); pwd -P))
 
 pushd $PARENT_PATH
 
-ADDR=$addr go test -v ./...
+CI=$ci go test -v ./...
 
 popd


### PR DESCRIPTION
This closes #29 by adding Travis for CI.

Little changes had to be done since nigiri travis uses different ports for bitcoin/liquid rpc services.