### PR TITLE
Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ The web server starts at default address `localhost:3000` with the following rou
   $ curl -X POST --data '{"address": "ert1q90dz89u8eudeswzynl3p2jke564ejc2cnfcwuq", "quantity": 1000}' http://localhost:3000/mint
   # {"asset":"2dcf5a8834645654911964ec3602426fd3b9b4017554d3f9c19403e7fc1411d3","txId":"7aed7d7f6b4193875e28036728fd360785324f85dfd84d2951cc2b18ea6c2718"}
   ```
+- `/registry` (only for Liquid chain) if faucet is enabled, to get extra info about one or more assets like `name` and `ticker`
+  ```
+  $ curl -X POST --data '{"assets": ["2dcf5a8834645654911964ec3602426fd3b9b4017554d3f9c19403e7fc1411d3"]}' http://localhost:3000/registry
+  # [{"asset":"2dcf5a8834645654911964ec3602426fd3b9b4017554d3f9c19403e7fc1411d3","contract":{"name":"test","ticker":"TST"},"issuance_txin":{"txid":"a0891447adb288e5a49fa10ede7016788a1b3a175cfb423eb133e45f6cefca84","vin":0},"name":"test","ticker":"TST"
+  ```
 - all [esplora](https://github.com/blockstream/esplora/blob/master/API.md) HTTP API endpoints
 
 **Note:**  
@@ -69,3 +74,4 @@ To customize server urls and ports use flags when running the binary:
 - `--use-mining` to have the esplora /broadcast endpoint wrapped so that a block is mined after the transaction
   is published
 - `--use-logger` to log every request/response
+- `--registry-path` to set the path for the asset registry db (default to current directory - Liquid only)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,9 @@ go 1.12
 
 require (
 	github.com/gorilla/mux v1.7.0
+	github.com/jcelliott/lumber v0.0.0-20160324203708-dd349441af25 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
+	github.com/sdomino/scribble v0.0.0-20191024200645-4116320640ba
 	github.com/sirupsen/logrus v1.4.0
 	golang.org/x/crypto v0.0.0-20190313024323-a1f597ede03a
 	golang.org/x/sys v0.0.0-20190312061237-fead79001313 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,11 +2,15 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gorilla/mux v1.7.0 h1:tOSd0UKHQd6urX6ApfOn4XdBMY6Sh1MfxV3kmaazO+U=
 github.com/gorilla/mux v1.7.0/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/jcelliott/lumber v0.0.0-20160324203708-dd349441af25 h1:EFT6MH3igZK/dIVqgGbTqWVvkZ7wJ5iGN03SVtvvdd8=
+github.com/jcelliott/lumber v0.0.0-20160324203708-dd349441af25/go.mod h1:sWkGw/wsaHtRsT9zGQ/WyJCotGWG/Anow/9hsAcBWRw=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sdomino/scribble v0.0.0-20191024200645-4116320640ba h1:8QAc9wFAf2b/9cAXskm0wBylObZ0bTpRcaP7ThjLPVQ=
+github.com/sdomino/scribble v0.0.0-20191024200645-4116320640ba/go.mod h1:W6zxGUBCXRR5QugSd/nFcFVmwoGnvpjiNY/JwT03Wew=
 github.com/sirupsen/logrus v1.4.0 h1:yKenngtzGh+cUSSh6GWbxW2abRqhYUSR/t/6+2QqNvE=
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/helpers/registry.go
+++ b/helpers/registry.go
@@ -1,0 +1,69 @@
+package helpers
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+)
+
+// Registry handles writing/reading json file where are stored info about issued asset
+type Registry struct {
+	path string
+}
+
+// NewRegistry returns a new Registry of error if the path is not absolute
+func NewRegistry(path string) *Registry {
+	r := &Registry{path}
+	return r
+}
+
+// AddEntry adds an entry to the register by previously making sure that
+// the incoming entry does not already exist in the registry
+func (r *Registry) AddEntry(asset string, issuanceInput map[string]interface{}, contract map[string]interface{}) error {
+	registry, err := r.load()
+	if err != nil {
+		return err
+	}
+
+	_, ok := registry[asset]
+	if ok {
+		return errors.New("Asset already exists on registry")
+	}
+	entry := map[string]interface{}{
+		"asset":         asset,
+		"issuance_txin": issuanceInput,
+		"contract":      contract,
+		"name":          contract["name"].(string),
+		"ticker":        contract["ticker"].(string),
+	}
+	registry[asset] = entry
+	return r.save(registry)
+}
+
+func (r *Registry) load() (map[string]interface{}, error) {
+	file, err := os.OpenFile("registry.json", os.O_RDONLY|os.O_CREATE, 0755)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	decoder := json.NewDecoder(file)
+	data := map[string]interface{}{}
+
+	decoder.Decode(&data)
+
+	return data, nil
+}
+
+func (r *Registry) save(payload map[string]interface{}) error {
+	file, err := os.OpenFile("registry.json", os.O_WRONLY|os.O_CREATE, 0755)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	encoder := json.NewEncoder(file)
+	encoder.SetIndent("", "   ")
+	encoder.Encode(payload)
+	return nil
+}

--- a/helpers/registry.go
+++ b/helpers/registry.go
@@ -4,40 +4,84 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"strings"
+
+	"github.com/sdomino/scribble"
 )
 
 // Registry handles writing/reading json file where are stored info about issued asset
 type Registry struct {
-	path string
+	db *scribble.Driver
 }
 
 // NewRegistry returns a new Registry of error if the path is not absolute
-func NewRegistry(path string) *Registry {
-	r := &Registry{path}
-	return r
+func NewRegistry(path string) (*Registry, error) {
+	r := &Registry{}
+	db, err := scribble.New(path, nil)
+	if err != nil {
+		return nil, err
+	}
+	r.db = db
+	return r, nil
 }
 
 // AddEntry adds an entry to the register by previously making sure that
 // the incoming entry does not already exist in the registry
 func (r *Registry) AddEntry(asset string, issuanceInput map[string]interface{}, contract map[string]interface{}) error {
-	registry, err := r.load()
-	if err != nil {
+	entry := map[string]interface{}{}
+	err := r.db.Read("registry", asset, &entry)
+	if err != nil && !strings.Contains(err.Error(), "no such file or directory") {
 		return err
 	}
 
-	_, ok := registry[asset]
-	if ok {
+	if len(entry) != 0 {
 		return errors.New("Asset already exists on registry")
 	}
-	entry := map[string]interface{}{
+
+	entry = map[string]interface{}{
 		"asset":         asset,
 		"issuance_txin": issuanceInput,
 		"contract":      contract,
 		"name":          contract["name"].(string),
 		"ticker":        contract["ticker"].(string),
 	}
-	registry[asset] = entry
-	return r.save(registry)
+	return r.db.Write("registry", asset, entry)
+}
+
+// GetEntry returns and entry if it exist in registry or NIL
+func (r *Registry) GetEntry(asset string) (interface{}, error) {
+	entry := map[string]interface{}{}
+	err := r.db.Read("registry", asset, &entry)
+	if err != nil {
+		return nil, err
+	}
+
+	return entry, nil
+}
+
+func (r *Registry) GetEntries(assets []interface{}) ([]interface{}, error) {
+	entries := []interface{}{}
+
+	if len(assets) == 0 {
+		records, err := r.db.ReadAll("registry")
+		if err != nil {
+			return nil, err
+		}
+
+		for _, f := range records {
+			var entry interface{}
+			json.Unmarshal([]byte(f), &entry)
+			entries = append(entries, entry)
+		}
+	} else {
+		for _, asset := range assets {
+			var entry interface{}
+			r.db.Read("registry", asset.(string), &entry)
+			entries = append(entries, entry)
+		}
+	}
+
+	return entries, nil
 }
 
 func (r *Registry) load() (map[string]interface{}, error) {

--- a/helpers/registry.go
+++ b/helpers/registry.go
@@ -49,7 +49,7 @@ func (r *Registry) AddEntry(asset string, issuanceInput map[string]interface{}, 
 }
 
 // GetEntry returns and entry if it exist in registry or NIL
-func (r *Registry) GetEntry(asset string) (interface{}, error) {
+func (r *Registry) GetEntry(asset string) (map[string]interface{}, error) {
 	entry := map[string]interface{}{}
 	err := r.db.Read("registry", asset, &entry)
 	if err != nil {
@@ -59,8 +59,8 @@ func (r *Registry) GetEntry(asset string) (interface{}, error) {
 	return entry, nil
 }
 
-func (r *Registry) GetEntries(assets []interface{}) ([]interface{}, error) {
-	entries := []interface{}{}
+func (r *Registry) GetEntries(assets []interface{}) ([]map[string]interface{}, error) {
+	entries := []map[string]interface{}{}
 
 	if len(assets) == 0 {
 		records, err := r.db.ReadAll("registry")
@@ -69,13 +69,13 @@ func (r *Registry) GetEntries(assets []interface{}) ([]interface{}, error) {
 		}
 
 		for _, f := range records {
-			var entry interface{}
+			entry := map[string]interface{}{}
 			json.Unmarshal([]byte(f), &entry)
 			entries = append(entries, entry)
 		}
 	} else {
 		for _, asset := range assets {
-			var entry interface{}
+			entry := map[string]interface{}{}
 			r.db.Read("registry", asset.(string), &entry)
 			entries = append(entries, entry)
 		}

--- a/helpers/registry.go
+++ b/helpers/registry.go
@@ -3,7 +3,6 @@ package helpers
 import (
 	"encoding/json"
 	"errors"
-	"os"
 	"strings"
 
 	"github.com/sdomino/scribble"
@@ -52,7 +51,8 @@ func (r *Registry) AddEntry(asset string, issuanceInput map[string]interface{}, 
 func (r *Registry) GetEntry(asset string) (map[string]interface{}, error) {
 	entry := map[string]interface{}{}
 	err := r.db.Read("registry", asset, &entry)
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "no such file or directory") {
+
 		return nil, err
 	}
 
@@ -82,32 +82,4 @@ func (r *Registry) GetEntries(assets []interface{}) ([]map[string]interface{}, e
 	}
 
 	return entries, nil
-}
-
-func (r *Registry) load() (map[string]interface{}, error) {
-	file, err := os.OpenFile("registry.json", os.O_RDONLY|os.O_CREATE, 0755)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
-	decoder := json.NewDecoder(file)
-	data := map[string]interface{}{}
-
-	decoder.Decode(&data)
-
-	return data, nil
-}
-
-func (r *Registry) save(payload map[string]interface{}) error {
-	file, err := os.OpenFile("registry.json", os.O_WRONLY|os.O_CREATE, 0755)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	encoder := json.NewEncoder(file)
-	encoder.SetIndent("", "   ")
-	encoder.Encode(payload)
-	return nil
 }

--- a/main.go
+++ b/main.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 	"time"
 
+	log "github.com/sirupsen/logrus"
 	cfg "github.com/vulpemventures/nigiri-chopsticks/config"
 	"github.com/vulpemventures/nigiri-chopsticks/router"
-	log "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/acme/autocert"
 )
 

--- a/router/electrs_handler.go
+++ b/router/electrs_handler.go
@@ -1,10 +1,56 @@
 package router
 
 import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/vulpemventures/nigiri-chopsticks/helpers"
 )
+
+type transport struct {
+	r *helpers.Registry
+}
+
+func (t *transport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
+	resp, err = http.DefaultTransport.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// check when request path is /asset/{asset_id}
+	if strings.HasPrefix(req.URL.Path, "/asset/") {
+		if s := strings.Split(req.URL.Path, "/"); len(s) == 3 {
+			// parse response body
+			payload, _ := ioutil.ReadAll(resp.Body)
+			body := map[string]interface{}{}
+			json.Unmarshal(payload, &body)
+
+			// get registry entry for asset
+			asset := body["asset_id"].(string)
+			entry, _ := t.r.GetEntry(asset)
+
+			// if entry exist add extra info to response
+			if len(entry) > 0 {
+				body["name"] = entry["name"]
+				body["ticker"] = entry["ticker"]
+				payload, _ = json.Marshal(body)
+			}
+
+			newBody := ioutil.NopCloser(bytes.NewReader(payload))
+			resp.Body = newBody
+			resp.ContentLength = int64(len(payload))
+			resp.Header.Set("Content-Length", strconv.Itoa(len(payload)))
+		}
+	}
+
+	return resp, nil
+}
 
 // HandleElectrsRequest forwards every request to the electrs HTTP server
 func (r *Router) HandleElectrsRequest(res http.ResponseWriter, req *http.Request) {
@@ -17,5 +63,6 @@ func (r *Router) HandleElectrsRequest(res http.ResponseWriter, req *http.Request
 	req.URL.Scheme = parsedURL.Scheme
 
 	proxy := httputil.NewSingleHostReverseProxy(parsedURL)
+	proxy.Transport = &transport{r.Registry}
 	proxy.ServeHTTP(res, req)
 }

--- a/router/electrs_handler_test.go
+++ b/router/electrs_handler_test.go
@@ -1,0 +1,72 @@
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestAssetEndpointWithExtraInfo(t *testing.T) {
+	r := NewTestRouter(withLiquid)
+	resp := mintRequest(r, liquidAddress, assetQuantity, name, ticker)
+
+	parsedResp := map[string]interface{}{}
+	json.Unmarshal(resp.Body.Bytes(), &parsedResp)
+	asset := parsedResp["asset"].(string)
+
+	time.Sleep(5 * time.Second)
+
+	resp = assetRequest(r, asset)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("Expected status %d, got: %d\n", http.StatusOK, resp.Code)
+	}
+
+	parsedResp = map[string]interface{}{}
+	json.Unmarshal(resp.Body.Bytes(), &parsedResp)
+	resName := parsedResp["name"].(string)
+	resTicker := parsedResp["ticker"].(string)
+
+	if strings.Compare(name, resName) != 0 {
+		t.Fatalf("Expected asset name: %s, got: %s\n", name, resName)
+	}
+	if strings.Compare(ticker, resTicker) != 0 {
+		t.Fatalf("Expected asset ticker: %s, got: %s\n", ticker, resTicker)
+	}
+}
+
+func TestAssetEndpointWithoutExtraInfo(t *testing.T) {
+	r := NewTestRouter(withLiquid)
+	resp := mintRequest(r, liquidAddress, assetQuantity, nil, nil)
+
+	parsedResp := map[string]interface{}{}
+	json.Unmarshal(resp.Body.Bytes(), &parsedResp)
+	asset := parsedResp["asset"].(string)
+
+	time.Sleep(5 * time.Second)
+
+	resp = assetRequest(r, asset)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("Expected status %d, got: %d\n", http.StatusOK, resp.Code)
+	}
+
+	parsedResp = map[string]interface{}{}
+	json.Unmarshal(resp.Body.Bytes(), &parsedResp)
+
+	if parsedResp["name"] != nil {
+		t.Fatalf("Asset name should not be defined")
+	}
+
+	if parsedResp["ticker"] != nil {
+		t.Fatalf("Asset ticker should not be defined")
+	}
+}
+
+func assetRequest(r *Router, asset interface{}) *httptest.ResponseRecorder {
+	path := fmt.Sprintf("/asset/%s", asset)
+	req, _ := http.NewRequest("GET", path, nil)
+	return doRequest(r, req)
+}

--- a/router/faucet_handler.go
+++ b/router/faucet_handler.go
@@ -48,12 +48,10 @@ func (r *Router) HandleMintRequest(res http.ResponseWriter, req *http.Request) {
 		http.Error(res, "Malformed Request", http.StatusBadRequest)
 		return
 	}
-	contract := body["contract"]
-	if contract != nil {
-		c := contract.(map[string]interface{})
-		name := c["name"]
-		ticker := c["ticker"]
-		if name == nil || ticker == nil {
+	name := body["name"]
+	ticker := body["ticker"]
+	if name != nil || ticker != nil {
+		if ticker == nil || name == nil {
 			http.Error(res, "Malformed Request", http.StatusBadRequest)
 			return
 		}
@@ -65,8 +63,12 @@ func (r *Router) HandleMintRequest(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if contract != nil {
-		r.Registry.AddEntry(resp["asset"].(string), resp["issuance_txin"].(map[string]interface{}), contract.(map[string]interface{}))
+	if name != nil {
+		contract := map[string]interface{}{
+			"name":   name,
+			"ticker": ticker,
+		}
+		r.Registry.AddEntry(resp["asset"].(string), resp["issuance_txin"].(map[string]interface{}), contract)
 	}
 
 	if r.Config.IsMiningEnabled() {

--- a/router/faucet_handler.go
+++ b/router/faucet_handler.go
@@ -27,8 +27,8 @@ func (r *Router) HandleFaucetRequest(res http.ResponseWriter, req *http.Request)
 
 	if r.Config.IsMiningEnabled() {
 		r.Faucet.Mine(1)
-		json.NewEncoder(res).Encode(map[string]string{"txId": tx})
 	}
+	json.NewEncoder(res).Encode(map[string]string{"txId": tx})
 	return
 }
 
@@ -73,8 +73,9 @@ func (r *Router) HandleMintRequest(res http.ResponseWriter, req *http.Request) {
 
 	if r.Config.IsMiningEnabled() {
 		r.Faucet.Mine(1)
-		json.NewEncoder(res).Encode(resp)
 	}
+
+	json.NewEncoder(res).Encode(resp)
 	return
 }
 

--- a/router/faucet_handler_test.go
+++ b/router/faucet_handler_test.go
@@ -2,9 +2,11 @@ package router
 
 import (
 	"bytes"
-	"fmt"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -19,6 +21,19 @@ const (
 	badLiquidAddress = ""
 	assetQuantity    = 1000
 	badAssetQuantity = -1
+)
+
+var (
+	contract = map[string]string{
+		"name":   "test",
+		"ticker": "TST",
+	}
+	badContract1 = map[string]string{
+		"name": "test",
+	}
+	badContract2 = map[string]string{
+		"ticker": "TST",
+	}
 )
 
 func TestBitcoinFaucet(t *testing.T) {
@@ -49,30 +64,14 @@ func TestBitcoinFaucet(t *testing.T) {
 	}
 }
 
-func TestBitcoinFaucetBadRequestShouldFail(t *testing.T) {
+func TestBitcoinFaucetShouldFail(t *testing.T) {
 	r := NewTestRouter(!withLiquid)
 
-	resp := faucetRequest(r, badBtcAddress)
-	if resp.Code == http.StatusOK {
-		t.Fatalf("Should return error, got status: %d\n", resp.Code)
-	}
+	resp := faucetRequest(r, nil)
+	checkFailed(t, resp, "Malformed Request")
 
-	err := resp.Body.String()
-	expectedError := "Invalid address"
-	if !strings.Contains(err, expectedError) {
-		t.Fatalf("Expected error: %s, got: %s\n", expectedError, err)
-	}
-
-	resp = faucetBadRequest(r)
-	if resp.Code == http.StatusOK {
-		t.Fatalf("Should return error, got status: %d\n", resp.Code)
-	}
-
-	err = resp.Body.String()
-	expectedError = "Malformed Request"
-	if !strings.Contains(err, expectedError) {
-		t.Fatalf("Expected error: %s, got: %s\n", expectedError, err)
-	}
+	resp = faucetRequest(r, badLiquidAddress)
+	checkFailed(t, resp, "Invalid address")
 }
 
 func TestLiquidFaucet(t *testing.T) {
@@ -102,7 +101,7 @@ func TestLiquidFaucet(t *testing.T) {
 	}
 	prevBlockCount, _ = strconv.Atoi(blockCountResp.Body.String())
 
-	resp = mintRequest(r, liquidAddress, assetQuantity)
+	resp = mintRequest(r, liquidAddress, assetQuantity, contract)
 	if resp.Code != http.StatusOK {
 		t.Fatalf("Expected status %d, got: %d\n", http.StatusOK, resp.Code)
 	}
@@ -115,84 +114,41 @@ func TestLiquidFaucet(t *testing.T) {
 	}
 }
 
-func TestLiquidFaucetBadRequestShouldFail(t *testing.T) {
+func TestLiquidFaucetShouldFail(t *testing.T) {
 	r := NewTestRouter(withLiquid)
 
-	resp := faucetRequest(r, badLiquidAddress)
-	if resp.Code == http.StatusOK {
-		t.Fatalf("Should return error, got status: %d\n", resp.Code)
-	}
+	resp := faucetRequest(r, nil)
+	checkFailed(t, resp, "Malformed Request")
 
-	err := resp.Body.String()
-	expectedError := "Invalid address"
-	if !strings.Contains(err, expectedError) {
-		t.Fatalf("Expected error: %s, got: %s\n", expectedError, err)
-	}
+	resp = faucetRequest(r, badLiquidAddress)
+	checkFailed(t, resp, "Invalid address")
 
-	resp = mintRequest(r, badLiquidAddress, assetQuantity)
-	if resp.Code == http.StatusOK {
-		t.Fatalf("Should return error, got status: %d\n", resp.Code)
-	}
+	resp = mintRequest(r, nil, assetQuantity, nil)
+	checkFailed(t, resp, "Malformed Request")
 
-	err = resp.Body.String()
-	if !strings.Contains(err, expectedError) {
-		t.Fatalf("Expected error: %s, got: %s\n", expectedError, err)
-	}
+	resp = mintRequest(r, liquidAddress, nil, nil)
+	checkFailed(t, resp, "Malformed Request")
 
-	resp = mintRequest(r, liquidAddress, badAssetQuantity)
-	if resp.Code == http.StatusOK {
-		t.Fatalf("Should return error, got status: %d\n", resp.Code)
-	}
+	resp = mintRequest(r, badLiquidAddress, assetQuantity, nil)
+	checkFailed(t, resp, "Invalid address")
 
-	err = resp.Body.String()
-	expectedError = "Amount out of range"
-	if !strings.Contains(err, expectedError) {
-		t.Fatalf("Expected error: %s, got: %s\n", expectedError, err)
-	}
+	resp = mintRequest(r, liquidAddress, badAssetQuantity, nil)
+	checkFailed(t, resp, "Amount out of range")
 
-	resp = faucetBadRequest(r)
-	if resp.Code == http.StatusOK {
-		t.Fatalf("Should return error, got status: %d\n", resp.Code)
-	}
+	resp = mintRequest(r, liquidAddress, assetQuantity, badContract1)
+	checkFailed(t, resp, "Malformed Request")
 
-	err = resp.Body.String()
-	expectedError = "Malformed Request"
-	if !strings.Contains(err, expectedError) {
-		t.Fatalf("Expected error: %s, got: %s\n", expectedError, err)
-	}
+	resp = mintRequest(r, liquidAddress, assetQuantity, badContract2)
+	checkFailed(t, resp, "Malformed Request")
 
-	resp = mintBadRequest(r, "", assetQuantity)
-	if resp.Code == http.StatusOK {
-		t.Fatalf("Should return error, got status: %d\n", resp.Code)
-	}
-
-	err = resp.Body.String()
-	expectedError = "Malformed Request"
-	if !strings.Contains(err, expectedError) {
-		t.Fatalf("Expected error: %s, got: %s\n", expectedError, err)
-	}
-
-	resp = mintBadRequest(r, liquidAddress, 0)
-	if resp.Code == http.StatusOK {
-		t.Fatalf("Should return error, got status: %d\n", resp.Code)
-	}
-
-	err = resp.Body.String()
-	expectedError = "Malformed Request"
-	if !strings.Contains(err, expectedError) {
-		t.Fatalf("Expected error: %s, got: %s\n", expectedError, err)
-	}
+	os.Remove(filepath.Join(r.Config.RegistryPath(), "registry.json"))
 }
 
-func faucetRequest(r *Router, address string) *httptest.ResponseRecorder {
-	payload := []byte(fmt.Sprintf(`{"address": "%s"}`, address))
-	req, _ := http.NewRequest("POST", "/faucet", bytes.NewBuffer(payload))
-
-	return doRequest(r, req)
-}
-
-func faucetBadRequest(r *Router) *httptest.ResponseRecorder {
-	payload := []byte(fmt.Sprintf("{}"))
+func faucetRequest(r *Router, address interface{}) *httptest.ResponseRecorder {
+	request := map[string]interface{}{
+		"address": address,
+	}
+	payload, _ := json.Marshal(request)
 	req, _ := http.NewRequest("POST", "/faucet", bytes.NewBuffer(payload))
 
 	return doRequest(r, req)
@@ -203,19 +159,14 @@ func blockCountRequest(r *Router) *httptest.ResponseRecorder {
 	return doRequest(r, req)
 }
 
-func mintRequest(r *Router, address string, quantity float64) *httptest.ResponseRecorder {
-	payload := []byte(fmt.Sprintf(`{"address": "%s", "quantity": %f}`, address, quantity))
-	req, _ := http.NewRequest("POST", "/mint", bytes.NewBuffer(payload))
-	return doRequest(r, req)
-}
-
-func mintBadRequest(r *Router, address string, quantity float64) *httptest.ResponseRecorder {
-	payload := []byte(fmt.Sprintf(`{"address": "%s", "quantity": %f}`, address, quantity))
-	if address == "" {
-		payload = []byte(fmt.Sprintf(`{"quantity": %f}`, quantity))
-	} else {
-		payload = []byte(fmt.Sprintf(`{"address": %s}`, address))
+func mintRequest(r *Router, address, quantity, contract interface{}) *httptest.ResponseRecorder {
+	request := map[string]interface{}{
+		"address":  address,
+		"quantity": quantity,
+		"contract": contract,
 	}
+	payload, _ := json.Marshal(request)
+
 	req, _ := http.NewRequest("POST", "/mint", bytes.NewBuffer(payload))
 	return doRequest(r, req)
 }
@@ -224,4 +175,15 @@ func doRequest(r *Router, req *http.Request) *httptest.ResponseRecorder {
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 	return rr
+}
+
+func checkFailed(t *testing.T, resp *httptest.ResponseRecorder, expectedError string) {
+	if resp.Code == http.StatusOK {
+		t.Fatalf("Should return error, got status: %d\n", resp.Code)
+	}
+
+	err := resp.Body.String()
+	if !strings.Contains(err, expectedError) {
+		t.Fatalf("Expected error: %s, got: %s\n", expectedError, err)
+	}
 }

--- a/router/faucet_handler_test.go
+++ b/router/faucet_handler_test.go
@@ -21,19 +21,8 @@ const (
 	badLiquidAddress = ""
 	assetQuantity    = 1000
 	badAssetQuantity = -1
-)
-
-var (
-	contract = map[string]string{
-		"name":   "test",
-		"ticker": "TST",
-	}
-	badContract1 = map[string]string{
-		"name": "test",
-	}
-	badContract2 = map[string]string{
-		"ticker": "TST",
-	}
+	name             = "test"
+	ticker           = "TST"
 )
 
 func TestBitcoinFaucet(t *testing.T) {
@@ -101,7 +90,7 @@ func TestLiquidFaucet(t *testing.T) {
 	}
 	prevBlockCount, _ = strconv.Atoi(blockCountResp.Body.String())
 
-	resp = mintRequest(r, liquidAddress, assetQuantity, contract)
+	resp = mintRequest(r, liquidAddress, assetQuantity, name, ticker)
 	if resp.Code != http.StatusOK {
 		t.Fatalf("Expected status %d, got: %d\n", http.StatusOK, resp.Code)
 	}
@@ -123,25 +112,25 @@ func TestLiquidFaucetShouldFail(t *testing.T) {
 	resp = faucetRequest(r, badLiquidAddress)
 	checkFailed(t, resp, "Invalid address")
 
-	resp = mintRequest(r, nil, assetQuantity, nil)
+	resp = mintRequest(r, nil, assetQuantity, nil, nil)
 	checkFailed(t, resp, "Malformed Request")
 
-	resp = mintRequest(r, liquidAddress, nil, nil)
+	resp = mintRequest(r, liquidAddress, nil, nil, nil)
 	checkFailed(t, resp, "Malformed Request")
 
-	resp = mintRequest(r, badLiquidAddress, assetQuantity, nil)
+	resp = mintRequest(r, badLiquidAddress, assetQuantity, nil, nil)
 	checkFailed(t, resp, "Invalid address")
 
-	resp = mintRequest(r, liquidAddress, badAssetQuantity, nil)
+	resp = mintRequest(r, liquidAddress, badAssetQuantity, nil, nil)
 	checkFailed(t, resp, "Amount out of range")
 
-	resp = mintRequest(r, liquidAddress, assetQuantity, badContract1)
+	resp = mintRequest(r, liquidAddress, assetQuantity, name, nil)
 	checkFailed(t, resp, "Malformed Request")
 
-	resp = mintRequest(r, liquidAddress, assetQuantity, badContract2)
+	resp = mintRequest(r, liquidAddress, assetQuantity, nil, name)
 	checkFailed(t, resp, "Malformed Request")
 
-	os.Remove(filepath.Join(r.Config.RegistryPath(), "registry.json"))
+	os.RemoveAll(filepath.Join(r.Config.RegistryPath(), "registry"))
 }
 
 func faucetRequest(r *Router, address interface{}) *httptest.ResponseRecorder {
@@ -159,11 +148,12 @@ func blockCountRequest(r *Router) *httptest.ResponseRecorder {
 	return doRequest(r, req)
 }
 
-func mintRequest(r *Router, address, quantity, contract interface{}) *httptest.ResponseRecorder {
+func mintRequest(r *Router, address, quantity, name, ticker interface{}) *httptest.ResponseRecorder {
 	request := map[string]interface{}{
 		"address":  address,
 		"quantity": quantity,
-		"contract": contract,
+		"name":     name,
+		"ticker":   ticker,
 	}
 	payload, _ := json.Marshal(request)
 

--- a/router/main.go
+++ b/router/main.go
@@ -18,6 +18,7 @@ type Router struct {
 	Config    cfg.Config
 	RPCClient *helpers.RpcClient
 	Faucet    *faucet.Faucet
+	Registry  *helpers.Registry
 }
 
 // NewRouter returns a new Router instance
@@ -25,13 +26,14 @@ func NewRouter(config cfg.Config) *Router {
 	router := mux.NewRouter().StrictSlash(true)
 	rpcClient, _ := helpers.NewRpcClient(config.RPCServerURL(), false, 10)
 
-	r := &Router{router, config, rpcClient, nil}
+	r := &Router{router, config, rpcClient, nil, nil}
 
 	if r.Config.IsFaucetEnabled() {
 		faucet := faucet.NewFaucet(config.RPCServerURL(), rpcClient)
 		r.Faucet = faucet
 		r.HandleFunc("/faucet", r.HandleFaucetRequest).Methods("POST")
 		if config.Chain() == "liquid" {
+			r.Registry = helpers.NewRegistry(config.RegistryPath())
 			r.HandleFunc("/mint", r.HandleMintRequest).Methods("POST")
 		}
 

--- a/router/main.go
+++ b/router/main.go
@@ -33,8 +33,10 @@ func NewRouter(config cfg.Config) *Router {
 		r.Faucet = faucet
 		r.HandleFunc("/faucet", r.HandleFaucetRequest).Methods("POST")
 		if config.Chain() == "liquid" {
-			r.Registry = helpers.NewRegistry(config.RegistryPath())
+			registry, _ := helpers.NewRegistry(config.RegistryPath())
+			r.Registry = registry
 			r.HandleFunc("/mint", r.HandleMintRequest).Methods("POST")
+			r.HandleFunc("/registry", r.HandleRegistryRequest).Methods("POST")
 		}
 
 		status, blockHashes, err := r.Faucet.Fund()

--- a/router/registry_handler.go
+++ b/router/registry_handler.go
@@ -1,0 +1,28 @@
+package router
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// HandleRegistryRequest accepts a list of asset ids and returns info retrieved from
+// the asset registry about them
+func (r *Router) HandleRegistryRequest(res http.ResponseWriter, req *http.Request) {
+	res.Header().Set("Access-Control-Allow-Methods", "POST")
+
+	body := parseRequestBody(req.Body)
+	assets := body["assets"]
+	if assets == nil {
+		http.Error(res, "Malformed Request", http.StatusBadRequest)
+		return
+	}
+
+	entries, err := r.Registry.GetEntries(assets.([]interface{}))
+	if err != nil {
+		http.Error(res, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	json.NewEncoder(res).Encode(entries)
+	return
+}

--- a/router/registry_handler_test.go
+++ b/router/registry_handler_test.go
@@ -25,6 +25,12 @@ func TestRegistry(t *testing.T) {
 	if len(list) < 1 {
 		t.Fatalf("Expected entry list to not be empty")
 	}
+}
+
+func TestRegistryShouldFail(t *testing.T) {
+	r := NewTestRouter(withLiquid)
+	resp := registryRequest(r, nil)
+	checkFailed(t, resp, "Malformed Request")
 
 	os.RemoveAll(filepath.Join(r.Config.RegistryPath(), "registry"))
 }

--- a/router/registry_handler_test.go
+++ b/router/registry_handler_test.go
@@ -1,0 +1,40 @@
+package router
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRegistry(t *testing.T) {
+	r := NewTestRouter(withLiquid)
+	resp := mintRequest(r, liquidAddress, assetQuantity, name, ticker)
+	resp = registryRequest(r, []interface{}{})
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("Expected status %d, got: %d\n", http.StatusOK, resp.Code)
+	}
+
+	list := []interface{}{}
+	json.Unmarshal(resp.Body.Bytes(), &list)
+
+	if len(list) < 1 {
+		t.Fatalf("Expected entry list to not be empty")
+	}
+
+	os.RemoveAll(filepath.Join(r.Config.RegistryPath(), "registry"))
+}
+
+func registryRequest(r *Router, assets []interface{}) *httptest.ResponseRecorder {
+	request := map[string]interface{}{
+		"assets": assets,
+	}
+
+	payload, _ := json.Marshal(request)
+	req, _ := http.NewRequest("POST", "/registry", bytes.NewBuffer(payload))
+	return doRequest(r, req)
+}


### PR DESCRIPTION
This closes #31.

This also adds a `POST /registry` endpoint  that accepts a list of assets and returns the corresponding list of extra info for each asset.
If extra info for asset `i` are not found in registry, the `i`th elem of the response list will be `{}`.

Last but not least, the `GET /asset/{asset_id}` Esplora endpoint response is intercepted by chopsticks and enriched with extra data (`name` and `ticker`) retrieved from the registry if an entry is found