### PR TITLE
[Faucet] Specify an asset (for liquid mode) and an amount

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,19 +42,21 @@ nigiri-chopsticks $ ./build/nigiri-chopsticks-darwin-amd64
 The web server starts at default address `localhost:3000` with the following routes:
 
 - `/faucet` if faucet is enabled, to send funds to an address
-  - example:
+  - example for Bitcoin:
+  ```bash
+  $ curl -X POST --data '{"address": "2MsnWskyHaHvcZUHA4gnR3G95EnUmZQjzM8", "amount": 0.02}' http://localhost:3000/faucet
   ```
-  $ curl -X POST --data '{"address": "2MsnWskyHaHvcZUHA4gnR3G95EnUmZQjzM8"}' http://localhost:3000/faucet
-  # 142a3ef44ddb3f9f395bcd87d73d71ccc8d90566a219f8d57ff0a71822617413
+  - example for Liquid
+  ```bash
+  $ curl -X POST --data '{"address": "2MsnWskyHaHvcZUHA4gnR3G95EnUmZQjzM8", "asset": "2dcf5a8834645654911964ec3602426fd3b9b4017554d3f9c19403e7fc1411d3", "amount": 0.02}' http://localhost:3000/faucet
   ```
 - `/mint` (only for Liquid chain) if faucet is enabled, to issue an asset and sent all issuance amount to an address
   - example:
-  ```
+  ```bash
   $ curl -X POST --data '{"address": "ert1q90dz89u8eudeswzynl3p2jke564ejc2cnfcwuq", "quantity": 1000, "name": "TokenName", "ticker":"TKN"}' http://localhost:3000/mint
-  # {"asset":"2dcf5a8834645654911964ec3602426fd3b9b4017554d3f9c19403e7fc1411d3","txId":"7aed7d7f6b4193875e28036728fd360785324f85dfd84d2951cc2b18ea6c2718"}
   ```
 - `/registry` (only for Liquid chain) if faucet is enabled, to get extra info about one or more assets like `name` and `ticker`
-  ```
+  ```bash
   $ curl -X POST --data '{"assets": ["2dcf5a8834645654911964ec3602426fd3b9b4017554d3f9c19403e7fc1411d3"]}' http://localhost:3000/registry
   # [{"asset":"2dcf5a8834645654911964ec3602426fd3b9b4017554d3f9c19403e7fc1411d3","contract":{"name":"test","ticker":"TST"},"issuance_txin":{"txid":"a0891447adb288e5a49fa10ede7016788a1b3a175cfb423eb133e45f6cefca84","vin":0},"name":"test","ticker":"TST"
   ```
@@ -66,6 +68,7 @@ All requests to chopsticks are (optionally) logged using a logger inspired by [n
 
 To customize server urls and ports use flags when running the binary:
 
+- `--chain` one between `bitcoin` and `liquid`
 - `--addr` server listening address (default `localhost:3000`)
 - `--btc-addr` btc RPC server listening address (default `localhost:19001`)
 - `--btc-cookie` btc RPC server user and password (default `admin1:123`)

--- a/router/faucet_handler.go
+++ b/router/faucet_handler.go
@@ -66,7 +66,7 @@ func (r *Router) HandleMintRequest(res http.ResponseWriter, req *http.Request) {
 	amount, amtOk := body["amount"].(float64)
 
 	if !qtyOk && !amtOk {
-		http.Error(res, "Malformed Request: missing address", http.StatusBadRequest)
+		http.Error(res, "Malformed Request: missing amount", http.StatusBadRequest)
 		return
 	}
 

--- a/router/faucet_handler.go
+++ b/router/faucet_handler.go
@@ -13,13 +13,31 @@ func (r *Router) HandleFaucetRequest(res http.ResponseWriter, req *http.Request)
 	res.Header().Set("Access-Control-Allow-Methods", "POST")
 
 	body := parseRequestBody(req.Body)
-	address := body["address"]
-	if address == nil {
-		http.Error(res, "Malformed Request", http.StatusBadRequest)
+	address, ok := body["address"].(string)
+	if !ok {
+		http.Error(res, "Malformed Request: missing address", http.StatusBadRequest)
 		return
 	}
+	amount, ok := body["amount"].(float64)
+	if !ok {
+		// the default 100 000 000 satoshis
+		amount = 1
+	}
+	asset, ok := body["asset"].(string)
+	if !ok {
+		// this means sending bitcoin
+		asset = ""
+	}
 
-	status, tx, err := r.Faucet.NewTransaction(address.(string))
+	var status int
+	var tx string
+	var err error
+
+	if r.Config.Chain() == "liquid" {
+		status, tx, err = r.Faucet.SendLiquidTransaction(address, amount, asset)
+	} else {
+		status, tx, err = r.Faucet.SendBitcoinTransaction(address, amount)
+	}
 	if err != nil {
 		http.Error(res, err.Error(), status)
 		return
@@ -38,37 +56,55 @@ func (r *Router) HandleMintRequest(res http.ResponseWriter, req *http.Request) {
 	res.Header().Set("Access-Control-Allow-Methods", "POST")
 
 	body := parseRequestBody(req.Body)
-	address := body["address"]
-	if address == nil {
-		http.Error(res, "Malformed Request", http.StatusBadRequest)
+	address, ok := body["address"].(string)
+	if !ok {
+		http.Error(res, "Malformed Request: missing address", http.StatusBadRequest)
 		return
 	}
-	quantity := body["quantity"]
-	if quantity == nil {
-		http.Error(res, "Malformed Request", http.StatusBadRequest)
+	// NOTICE this is here for backward compatibility. We will deprecate and move to amount
+	quantity, qtyOk := body["quantity"].(float64)
+	amount, amtOk := body["amount"].(float64)
+
+	if !qtyOk && !amtOk {
+		http.Error(res, "Malformed Request: missing address", http.StatusBadRequest)
 		return
-	}
-	name := body["name"]
-	ticker := body["ticker"]
-	if name != nil || ticker != nil {
-		if ticker == nil || name == nil {
-			http.Error(res, "Malformed Request", http.StatusBadRequest)
-			return
-		}
 	}
 
-	status, resp, err := r.Faucet.Mint(address.(string), quantity.(float64))
+	if qtyOk && !amtOk {
+		amount = quantity
+	}
+
+	status, resp, err := r.Faucet.Mint(address, amount)
 	if err != nil {
 		http.Error(res, err.Error(), status)
 		return
 	}
 
-	if name != nil {
+	asset, ok := resp["asset"].(string)
+	if !ok {
+		http.Error(res, "Internal error", http.StatusInternalServerError)
+		return
+	}
+	issuanceTx, ok := resp["issuance_txin"].(map[string]interface{})
+	if !ok {
+		http.Error(res, "Internal error", http.StatusInternalServerError)
+		return
+	}
+
+	name, nameOk := body["name"].(string)
+	ticker, tickerOk := body["ticker"].(string)
+
+	if (nameOk && !tickerOk) || (!nameOk && tickerOk) {
+		http.Error(res, "Malformed Request: missing name or ticker", http.StatusBadRequest)
+		return
+	}
+
+	if nameOk && tickerOk {
 		contract := map[string]interface{}{
 			"name":   name,
 			"ticker": ticker,
 		}
-		r.Registry.AddEntry(resp["asset"].(string), resp["issuance_txin"].(map[string]interface{}), contract)
+		r.Registry.AddEntry(asset, issuanceTx, contract)
 	}
 
 	if r.Config.IsMiningEnabled() {

--- a/router/faucet_handler_test.go
+++ b/router/faucet_handler_test.go
@@ -99,7 +99,7 @@ func TestLiquidFaucet(t *testing.T) {
 	if resp.Code != http.StatusOK {
 		t.Fatalf("Expected status %d, got: %d\n", http.StatusOK, resp.Code)
 	}
-	time.Sleep(3 * time.Second)
+	time.Sleep(5 * time.Second)
 
 	var decodedBody map[string]interface{}
 	err = json.Unmarshal(resp.Body.Bytes(), &decodedBody)
@@ -116,7 +116,7 @@ func TestLiquidFaucet(t *testing.T) {
 	blockCount, _ = strconv.Atoi(blockCountResp.Body.String())
 	blockMined = blockCount - prevBlockCount
 	if blockMined < 1 {
-		t.Fatalf("Expected 1 block mined, got %d\n", blockMined)
+		t.Fatalf("Expected at least 1 block mined, got %d\n", blockMined)
 	}
 
 }

--- a/router/faucet_handler_test.go
+++ b/router/faucet_handler_test.go
@@ -107,15 +107,15 @@ func TestLiquidFaucet(t *testing.T) {
 		t.Fatalf("decoding response error")
 	}
 
-	resp2 := faucetRequest(r, liquidAddress, 25, decodedBody["asset"].(string))
+	resp2 := faucetRequest(r, liquidAddress, 0, decodedBody["asset"].(string))
 	if resp2.Code != http.StatusOK {
 		t.Fatalf("Expected status %d, got: %d\n", http.StatusOK, resp2.Code)
 	}
-	time.Sleep(2 * time.Second)
+	time.Sleep(5 * time.Second)
 	blockCountResp = blockCountRequest(r)
 	blockCount, _ = strconv.Atoi(blockCountResp.Body.String())
 	blockMined = blockCount - prevBlockCount
-	if blockMined != 1 {
+	if blockMined < 1 {
 		t.Fatalf("Expected 1 block mined, got %d\n", blockMined)
 	}
 
@@ -152,12 +152,13 @@ func TestLiquidFaucetShouldFail(t *testing.T) {
 }
 
 func faucetRequest(r *Router, address string, amount float64, asset string) *httptest.ResponseRecorder {
-	if amount <= 0 {
-		amount = 1
-	}
+
 	request := map[string]interface{}{
 		"address": address,
-		"amount":  amount,
+	}
+
+	if amount > 0 {
+		request["amount"] = amount
 	}
 
 	if len(asset) > 0 {

--- a/router/faucet_handler_test.go
+++ b/router/faucet_handler_test.go
@@ -34,7 +34,7 @@ func TestBitcoinFaucet(t *testing.T) {
 	}
 	prevBlockCount, _ := strconv.Atoi(blockCountResp.Body.String())
 
-	faucetResp := faucetRequest(r, btcAddress)
+	faucetResp := faucetRequest(r, btcAddress, 0, "")
 	if faucetResp.Code != http.StatusOK {
 		t.Fatalf("Expected status %d, got: %d\n", http.StatusOK, faucetResp.Code)
 	}
@@ -56,10 +56,10 @@ func TestBitcoinFaucet(t *testing.T) {
 func TestBitcoinFaucetShouldFail(t *testing.T) {
 	r := NewTestRouter(!withLiquid)
 
-	resp := faucetRequest(r, nil)
-	checkFailed(t, resp, "Malformed Request")
+	resp := faucetRequest(r, "", 0, "")
+	checkFailed(t, resp, "Invalid address")
 
-	resp = faucetRequest(r, badLiquidAddress)
+	resp = faucetRequest(r, badLiquidAddress, 0, "")
 	checkFailed(t, resp, "Invalid address")
 }
 
@@ -72,7 +72,7 @@ func TestLiquidFaucet(t *testing.T) {
 	}
 	prevBlockCount, _ := strconv.Atoi(blockCountResp.Body.String())
 
-	resp := faucetRequest(r, liquidAddress)
+	resp := faucetRequest(r, liquidAddress, 0, "")
 	if resp.Code != http.StatusOK {
 		t.Fatalf("Expected status %d, got: %d\n", http.StatusOK, resp.Code)
 	}
@@ -90,30 +90,48 @@ func TestLiquidFaucet(t *testing.T) {
 	}
 	prevBlockCount, _ = strconv.Atoi(blockCountResp.Body.String())
 
-	resp = mintRequest(r, liquidAddress, assetQuantity, name, ticker)
+	addrOfNode, err := getNewAddressFromNode(r)
+	if err != nil {
+		t.Fatalf("getNewAddressFromNode error")
+	}
+
+	resp = mintRequest(r, addrOfNode, assetQuantity, name, ticker)
 	if resp.Code != http.StatusOK {
 		t.Fatalf("Expected status %d, got: %d\n", http.StatusOK, resp.Code)
 	}
-	time.Sleep(5 * time.Second)
+	time.Sleep(3 * time.Second)
+
+	var decodedBody map[string]interface{}
+	err = json.Unmarshal(resp.Body.Bytes(), &decodedBody)
+	if err != nil {
+		t.Fatalf("decoding response error")
+	}
+
+	resp2 := faucetRequest(r, liquidAddress, 25, decodedBody["asset"].(string))
+	if resp2.Code != http.StatusOK {
+		t.Fatalf("Expected status %d, got: %d\n", http.StatusOK, resp2.Code)
+	}
+	time.Sleep(2 * time.Second)
 	blockCountResp = blockCountRequest(r)
 	blockCount, _ = strconv.Atoi(blockCountResp.Body.String())
 	blockMined = blockCount - prevBlockCount
 	if blockMined != 1 {
 		t.Fatalf("Expected 1 block mined, got %d\n", blockMined)
 	}
+
 }
 
 func TestLiquidFaucetShouldFail(t *testing.T) {
 	r := NewTestRouter(withLiquid)
 
-	resp := faucetRequest(r, nil)
-	checkFailed(t, resp, "Malformed Request")
-
-	resp = faucetRequest(r, badLiquidAddress)
+	resp := faucetRequest(r, "", 0, "")
 	checkFailed(t, resp, "Invalid address")
 
-	resp = mintRequest(r, nil, assetQuantity, nil, nil)
-	checkFailed(t, resp, "Malformed Request")
+	resp = faucetRequest(r, badLiquidAddress, 0, "")
+	checkFailed(t, resp, "Invalid address")
+
+	resp = mintRequest(r, "", assetQuantity, nil, nil)
+	checkFailed(t, resp, "Invalid address")
 
 	resp = mintRequest(r, liquidAddress, nil, nil, nil)
 	checkFailed(t, resp, "Malformed Request")
@@ -133,10 +151,19 @@ func TestLiquidFaucetShouldFail(t *testing.T) {
 	os.RemoveAll(filepath.Join(r.Config.RegistryPath(), "registry"))
 }
 
-func faucetRequest(r *Router, address interface{}) *httptest.ResponseRecorder {
+func faucetRequest(r *Router, address string, amount float64, asset string) *httptest.ResponseRecorder {
+	if amount <= 0 {
+		amount = 1
+	}
 	request := map[string]interface{}{
 		"address": address,
+		"amount":  amount,
 	}
+
+	if len(asset) > 0 {
+		request["asset"] = asset
+	}
+
 	payload, _ := json.Marshal(request)
 	req, _ := http.NewRequest("POST", "/faucet", bytes.NewBuffer(payload))
 
@@ -176,4 +203,13 @@ func checkFailed(t *testing.T, resp *httptest.ResponseRecorder, expectedError st
 	if !strings.Contains(err, expectedError) {
 		t.Fatalf("Expected error: %s, got: %s\n", expectedError, err)
 	}
+}
+
+func getNewAddressFromNode(r *Router) (string, error) {
+	_, resp, err := handleRPCRequest(r.RPCClient, "getnewaddress", nil)
+	if err != nil {
+		return "", err
+	}
+
+	return resp.(string), nil
 }

--- a/scripts/test
+++ b/scripts/test
@@ -3,12 +3,18 @@
 set -e
 
 case $1 in
-  local) ci="false";;
-  ci) ci="true";;
-  *) echo "Invalid option. Aborting."; exit 1;;
+local) ci="false" ;;
+ci) ci="true" ;;
+*)
+  echo "Specify a valid option via the CI environment variable. Aborting."
+  exit 1
+  ;;
 esac
 
-PARENT_PATH=$(dirname $(cd $(dirname $0); pwd -P))
+PARENT_PATH=$(dirname $(
+  cd $(dirname $0)
+  pwd -P
+))
 
 pushd $PARENT_PATH
 


### PR DESCRIPTION
This commit adds the possibility to specify an amount (different than the default 1 Bitcoin) for both chains and in case of chain `liquid` an additional parameter `asset` could be given to send an asset hash that is held by the Elements node wallet balance.