### PR TITLE
Update liquid faucet (sendtoaddress)

### DIFF
--- a/faucet/main.go
+++ b/faucet/main.go
@@ -27,7 +27,7 @@ func (f *Faucet) SendBitcoinTransaction(address string, amount float64) (int, st
 // SendLiquidTransaction calls the sendtoaddress method of the elements node to the given address with the fractional amount of the given asset hash.
 // If asset hash is empty will send Liquid Bitcoin
 func (f *Faucet) SendLiquidTransaction(address string, amount float64, asset string) (int, string, error) {
-	status, resp, err := helpers.HandleRPCRequest(f.rpcClient, "sendtoaddress", []interface{}{address, amount, "", "", false, false, 1, "UNSET", false, asset})
+	status, resp, err := helpers.HandleRPCRequest(f.rpcClient, "sendtoaddress", []interface{}{address, amount, "", "", false, false, 1, "UNSET", asset})
 	if err != nil {
 		return status, "", err
 	}


### PR DESCRIPTION
Last elements update removes the boolean param after `estimate_mode` in sendtoaddress RPC causing nigiri's faucet to fail.

this PR removes the outdated parameter.

@tiero  please review this