### PR TITLE
Remove param for unconf addr

### DIFF
--- a/router/address_handler.go
+++ b/router/address_handler.go
@@ -11,12 +11,11 @@ import (
 func (r *Router) HandleAddressRequest(res http.ResponseWriter, req *http.Request) {
 	res.Header().Set("Access-Control-Allow-Origin", "*")
 
-	status, resp, err := helpers.HandleRPCRequest(r.RPCClient, "getnewaddress", []interface{}{"", "bech32"})
+	status, resp, err := helpers.HandleRPCRequest(r.RPCClient, "getnewaddress", []interface{}{})
 	if err != nil {
 		http.Error(res, err.Error(), status)
 		return
 	}
 
 	json.NewEncoder(res).Encode(map[string]string{"address": resp.(string)})
-	return
 }


### PR DESCRIPTION
With newer elements version, the `getnewaddress` rpc returns by default a confidential segwit v0 address.

This removes the `bech32` param used by the `/address` endpoint when calling the underlying rpc, to prevent generating unconfidential addresses.

Please @bordalix review this.